### PR TITLE
6562 add unit tests for Processor 12 & Processor 13

### DIFF
--- a/epay3.Web.Api.Tests/App.config
+++ b/epay3.Web.Api.Tests/App.config
@@ -1,37 +1,34 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<appSettings>
+		<add key="ApiUri" value="https://api-sandbox.epaypolicy.com" />
 
-	<!--
-    <add key="ApiUri" value="https://localhost/epay3.Web.Api"/>
-    -->
-		
-	<add key="ApiUri" value="https://api-sandbox.epaypolicy.com"/>
-		
-	<!--
+		<!--
     Use these settings if impersonation is off.
-    <add key="ApiKey" value="3e18c84b5a434a"/>
-    <add key="ApiSecret" value="o0s9p23jsdf22va"/>
+    <add key="ApiKey" value="3e18c84b5a434a" />
+    <add key="ApiSecret" value="o0s9p23jsdf22va" />
     -->
 
-	<!--
+		<!--
     Use these settings if impersonation is on.
     -->
-    <add key="ApiKey" value="3e18c84b5a434c"/>
-    <add key="ApiSecret" value="o0s9p23jsdf22va"/>
+		<add key="ApiKey" value="3e18c84b5a434c" />
+		<add key="ApiSecret" value="o0s9p23jsdf22va" />
+		<add key="ApiPublicKey" value="82604ac77dee40b5ae8fceea7ef12d3" />
 
-    <add key="InvoiceApiKey" value="3e18c84b5a434b" />
-    <add key="InvoiceApiSecret" value="o0s9p23jsdf22va" />
+		<add key="InvoiceApiKey" value="3e18c84b5a434b" />
+		<add key="InvoiceApiSecret" value="o0s9p23jsdf22va" />
 
-    <add key="ImpersonationAccountKey" value="sdjf0xlsabb"/>
-    <add key="InvoicesImpersonationAccountKey" value="d9ca809edb6449e7aea033d45 "/>
-    <add key="ApiPublicKey" value="82604ac77dee40b5ae8fceea7ef12d3"/>
-    <add key="ImpersonationOnlyBatchId" value="4"/>
+		<add key="ImpersonationAccountKey" value="sdjf0xlsabb" />
+		<add key="InvoicesImpersonationAccountKey" value="d9ca809edb6449e7aea033d45 " />
+		<add key="ImpersonationOnlyBatchId" value="4" />
 
-    <!--
-    <add key="ApiUri" value="https://api.epay3.com"/>
-    <add key="ApiKey" value=""/>
-    <add key="ApiSecret" value=""/>
-    -->
+		<add key="ApiKey_Processor12" value="1f97a7c83bea45f" />
+		<add key="ApiSecret_Processor12" value="a95cbf3f62e649e" />
+		<add key="ApiPublicKey_Processor12" value="ae28b0c9ac494282a637752fb700a753" />
+
+		<add key="ApiKey_Processor13" value="" />
+		<add key="ApiSecret_Processor13" value="" />
+		<add key="ApiPublicKey_Processor13" value="" />
 	</appSettings>
 </configuration>

--- a/epay3.Web.Api.Tests/AutoPayFixture.cs
+++ b/epay3.Web.Api.Tests/AutoPayFixture.cs
@@ -1,50 +1,47 @@
-﻿using System;
-using System.Net;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using epay3.Web.Api.Sdk.Api;
+﻿using epay3.Web.Api.Sdk.Api;
 using epay3.Web.Api.Sdk.Model;
-using epay3.Web.Api.Sdk.Client;
+using epay3.Web.Api.Tests.TestData;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
+using System.Net;
 
 namespace epay3.Web.Api.Tests
 {
     [TestClass]
     public class When_posting_An_AutoPay
     {
+        private ITestData _testData;
+
+        private byte[] _plainTextBytes;
+        private AutoPayApi _autoPayApi;
+        private TokensApi _tokensApi;
 
         [TestInitialize]
         public void Initialize()
         {
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+            _testData = new TestData.Processor7();
+
+            _plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.InvoiceKey + ":" + _testData.InvoiceSecret);
+            _autoPayApi = new AutoPayApi(_testData.Uri);
+            _tokensApi = new TokensApi(_testData.Uri);
+            _autoPayApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(_plainTextBytes));
+            _tokensApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(_plainTextBytes));
         }
 
         [TestMethod]
         public void Should_Create_And_Get()
         {
-            // Setup
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.InvoiceKey + ":" + TestApiSettings.InvoiceSecret);
-            var autoPayApi = new AutoPayApi(TestApiSettings.Uri);
-            var tokensApi = new TokensApi(TestApiSettings.Uri);
             var postTokenRequestModel = new PostTokenRequestModel
             {
                 Payer = "John Doe",
                 EmailAddress = "jdoe@example.com",
-                CreditCardInformation = new CreditCardInformationModel
-                {
-                    AccountHolder = "John Doe",
-                    CardNumber = "4457119922390123",
-                    Cvc = "123",
-                    Month = 12,
-                    Year = DateTime.Now.Year + 1,
-                    PostalCode = "54321"
-                }
+                CreditCardInformation = _testData.Visa
             };
 
-            autoPayApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
-            tokensApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
-
             // Create Token
-            var tokenId = tokensApi.TokensPost(postTokenRequestModel);
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel);
 
             var id = Guid.NewGuid();
             var autopayRequestModel = new PostAutoPayRequestModel
@@ -58,9 +55,42 @@ namespace epay3.Web.Api.Tests
                 },
                 PublicTokenId = tokenId
             };
-            
-            var createdId = autoPayApi.AutoPayPost(autopayRequestModel);
-            var gotten = autoPayApi.AutoPayGet(createdId.Value);
+
+            var createdId = _autoPayApi.AutoPayPost(autopayRequestModel);
+            var gotten = _autoPayApi.AutoPayGet(createdId.Value);
+
+            Assert.IsNotNull(gotten);
+            Assert.AreEqual(tokenId, gotten.TokenId);
+        }
+
+        [TestMethod]
+        public void Should_Create_And_Get_Amex()
+        {
+            var postTokenRequestModel = new PostTokenRequestModel
+            {
+                Payer = "John Doe",
+                EmailAddress = "jdoe@example.com",
+                CreditCardInformation = _testData.Amex
+            };
+
+            // Create Token
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel);
+
+            var id = Guid.NewGuid();
+            var autopayRequestModel = new PostAutoPayRequestModel
+            {
+                EmailAddress = "test@test.com",
+                AttributeValues = new Dictionary<string, string>()
+                {
+                    ["accountCode"] = "123",
+                    ["postalCode"] = "78701",
+                    ["uniqueId"] = id.ToString()
+                },
+                PublicTokenId = tokenId
+            };
+
+            var createdId = _autoPayApi.AutoPayPost(autopayRequestModel);
+            var gotten = _autoPayApi.AutoPayGet(createdId.Value);
 
             Assert.IsNotNull(gotten);
             Assert.AreEqual(tokenId, gotten.TokenId);
@@ -69,30 +99,15 @@ namespace epay3.Web.Api.Tests
         [TestMethod]
         public void Should_Create_Get_And_Delete_With_Impersonation()
         {
-            // setup
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.Key + ":" + TestApiSettings.Secret);
-            var autoPayApi = new AutoPayApi(TestApiSettings.Uri);
-            var tokensApi = new TokensApi(TestApiSettings.Uri);
             var postTokenRequestModel = new PostTokenRequestModel
             {
                 Payer = "John Doe",
                 EmailAddress = "jdoe@example.com",
-                CreditCardInformation = new CreditCardInformationModel
-                {
-                    AccountHolder = "John Doe",
-                    CardNumber = "4457119922390123",
-                    Cvc = "123",
-                    Month = 12,
-                    Year = DateTime.Now.Year + 1,
-                    PostalCode = "54321"
-                }
+                CreditCardInformation = _testData.Visa
             };
 
-            autoPayApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
-            tokensApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
-
             //Create Token
-            var tokenId = tokensApi.TokensPost(postTokenRequestModel, TestApiSettings.InvoicesImpersonationAccountKey);
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel, _testData.InvoicesImpersonationAccountKey);
 
             var id = Guid.NewGuid();
             var autopayRequestModel = new PostAutoPayRequestModel
@@ -108,9 +123,9 @@ namespace epay3.Web.Api.Tests
             };
 
             // Create and get autopay
-            var createdId = autoPayApi.AutoPayPost(autopayRequestModel, TestApiSettings.InvoicesImpersonationAccountKey);
-            var gotten = autoPayApi.AutoPayGet(createdId.Value, TestApiSettings.InvoicesImpersonationAccountKey);
-            autoPayApi.AutoPayCancel(createdId.Value, TestApiSettings.InvoicesImpersonationAccountKey);
+            var createdId = _autoPayApi.AutoPayPost(autopayRequestModel, _testData.InvoicesImpersonationAccountKey);
+            var gotten = _autoPayApi.AutoPayGet(createdId.Value, _testData.InvoicesImpersonationAccountKey);
+            _autoPayApi.AutoPayCancel(createdId.Value, _testData.InvoicesImpersonationAccountKey);
 
             Assert.IsNotNull(gotten);
             Assert.AreEqual(tokenId, gotten.TokenId);
@@ -119,30 +134,15 @@ namespace epay3.Web.Api.Tests
         [TestMethod]
         public void Should_Create_And_Delete()
         {
-            // Setup
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.InvoiceKey + ":" + TestApiSettings.InvoiceSecret);
-            var autoPayApi = new AutoPayApi(TestApiSettings.Uri);
-            var tokensApi = new TokensApi(TestApiSettings.Uri);
             var postTokenRequestModel = new PostTokenRequestModel
             {
                 Payer = "John Doe",
                 EmailAddress = "jdoe@example.com",
-                CreditCardInformation = new CreditCardInformationModel
-                {
-                    AccountHolder = "John Doe",
-                    CardNumber = "4457119922390123",
-                    Cvc = "123",
-                    Month = 12,
-                    Year = DateTime.Now.Year + 1,
-                    PostalCode = "54321"
-                }
+                CreditCardInformation = _testData.Visa
             };
 
-            autoPayApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
-            tokensApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
-
             // Create Token
-            var tokenId = tokensApi.TokensPost(postTokenRequestModel);
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel);
 
             var autopayRequestModel = new PostAutoPayRequestModel
             {
@@ -155,8 +155,8 @@ namespace epay3.Web.Api.Tests
                 PublicTokenId = tokenId
             };
 
-            var createdId = autoPayApi.AutoPayPost(autopayRequestModel);
-            var result = autoPayApi.AutoPayCancel(createdId.Value);
+            var createdId = _autoPayApi.AutoPayPost(autopayRequestModel);
+            var result = _autoPayApi.AutoPayCancel(createdId.Value);
 
             Assert.IsTrue(result);
         }

--- a/epay3.Web.Api.Tests/BatchesFixture.cs
+++ b/epay3.Web.Api.Tests/BatchesFixture.cs
@@ -1,11 +1,8 @@
 ﻿using epay3.Web.Api.Sdk.Api;
+using epay3.Web.Api.Tests.TestData;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace epay3.Web.Api.Tests
 {
@@ -13,15 +10,18 @@ namespace epay3.Web.Api.Tests
     public class BatchesFixture
     {
         private BatchesApi _batchesApi;
+        private ITestData _testData;
 
         [TestInitialize]
         public void Initialize()
         {
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
 
-            _batchesApi = new BatchesApi(TestApiSettings.Uri);
+            _testData = new TestData.Processor7();
 
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.Key + ":" + TestApiSettings.Secret);
+            _batchesApi = new BatchesApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
 
             _batchesApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
         }
@@ -34,18 +34,18 @@ namespace epay3.Web.Api.Tests
             // Should get successfully.
             Assert.IsTrue(result.Batches.Count > 0);
             Assert.IsTrue(result.TotalRecords > 0);
-            Assert.IsTrue(result.Batches.All(x => x.Id != TestApiSettings.ImpersonationOnlyBatchId));
+            Assert.IsTrue(result.Batches.All(x => x.Id != _testData.ImpersonationOnlyBatchId));
         }
 
         [TestMethod]
         public void Should_Get_Successfully_With_Impersonation_Key()
         {
-            var result = _batchesApi.BatchesGet(null, TestApiSettings.ImpersonationAccountKey);
+            var result = _batchesApi.BatchesGet(null, _testData.ImpersonationAccountKey);
 
             // Should get successfully.
             Assert.IsTrue(result.Batches.Count > 0);
             Assert.IsTrue(result.TotalRecords > 0);
-            Assert.IsTrue(result.Batches.Any(x => x.Id == TestApiSettings.ImpersonationOnlyBatchId));
+            Assert.IsTrue(result.Batches.Any(x => x.Id == _testData.ImpersonationOnlyBatchId));
         }
     }
 }

--- a/epay3.Web.Api.Tests/InvoicesFixture.cs
+++ b/epay3.Web.Api.Tests/InvoicesFixture.cs
@@ -1,12 +1,9 @@
 ﻿using epay3.Web.Api.Sdk.Api;
 using epay3.Web.Api.Sdk.Model;
+using epay3.Web.Api.Tests.TestData;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace epay3.Web.Api.Tests
 {
@@ -14,40 +11,44 @@ namespace epay3.Web.Api.Tests
     public class InvoicesFixture
     {
         private TransactionsApi _transactionsApi;
+        private ITestData _testData;
 
         [TestInitialize]
         public void Initialize()
         {
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
 
-            _transactionsApi = new TransactionsApi(TestApiSettings.Uri);
+            _testData = new TestData.Processor7();
 
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.Key + ":" + TestApiSettings.Secret); 
+            _transactionsApi = new TransactionsApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
             _transactionsApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
+
+            _testData = new TestData.Processor7();
         }
 
         private InvoicesApi GetApi(bool useImpersonation)
         {
-            var invoicesApi = new InvoicesApi(TestApiSettings.Uri);
+            var invoicesApi = new InvoicesApi(_testData.Uri);
             var plainTextBytes = new byte[0];
             if (useImpersonation)
             {
-                plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.Key + ":" + TestApiSettings.Secret);
+                plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
                 invoicesApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
                 return invoicesApi;
             }
 
-            plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.InvoiceKey + ":" + TestApiSettings.InvoiceSecret);
+            plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.InvoiceKey + ":" + _testData.InvoiceSecret);
             invoicesApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
             return invoicesApi;
-            
         }
 
         [TestMethod]
         public void Should_Get_Successfully_With_Impersonation_Key()
         {
             var invoicesApi = GetApi(true);
-            var result = invoicesApi.InvoicesGet(new Dictionary<string, string>() { ["accountCode"] = "123", ["postalCode"] = "78701" }, TestApiSettings.InvoicesImpersonationAccountKey);
+            var result = invoicesApi.InvoicesGet(new Dictionary<string, string>() { ["accountCode"] = "123", ["postalCode"] = "78701" }, _testData.InvoicesImpersonationAccountKey);
 
             // Should post successfully.
             Assert.IsTrue(result.Status == InvoiceStatus.Success);
@@ -85,7 +86,7 @@ namespace epay3.Web.Api.Tests
             };
 
             var invoicesApi = GetApi(true);
-            bool success = invoicesApi.InvoicesUpdate(updateInvoicesRequestModel, TestApiSettings.InvoicesImpersonationAccountKey);
+            bool success = invoicesApi.InvoicesUpdate(updateInvoicesRequestModel, _testData.InvoicesImpersonationAccountKey);
 
             // Should post successfully.
             Assert.IsTrue(success);
@@ -100,19 +101,11 @@ namespace epay3.Web.Api.Tests
                 Payer = "John Smith",
                 EmailAddress = "jsmith@example.com",
                 Amount = amount,
-                BankAccountInformation = new BankAccountInformationModel
-                {
-                    AccountHolder = "John Smith",
-                    FirstName = "John",
-                    LastName = "Smith",
-                    AccountNumber = "4545454",
-                    RoutingNumber = "111000025",
-                    AccountType = AccountType.Personalsavings
-                },
+                BankAccountInformation = _testData.Ach2,
                 Comments = "Sample comments"
             };
 
-            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, TestApiSettings.InvoicesImpersonationAccountKey);
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, _testData.InvoicesImpersonationAccountKey);
 
             // Should return a valid Id.
             Assert.IsTrue(response.Id > 0);
@@ -140,7 +133,7 @@ namespace epay3.Web.Api.Tests
                 }
             };
 
-            bool success = GetApi(true).InvoicesUpdate(updateInvoicesRequestModel, TestApiSettings.InvoicesImpersonationAccountKey);
+            bool success = GetApi(true).InvoicesUpdate(updateInvoicesRequestModel, _testData.InvoicesImpersonationAccountKey);
 
             // Should post successfully.
             Assert.IsTrue(success);

--- a/epay3.Web.Api.Tests/IvrSessionsFixture.cs
+++ b/epay3.Web.Api.Tests/IvrSessionsFixture.cs
@@ -1,12 +1,8 @@
 ﻿using epay3.Web.Api.Sdk.Api;
 using epay3.Web.Api.Sdk.Model;
+using epay3.Web.Api.Tests.TestData;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace epay3.Web.Api.Tests
 {
@@ -14,15 +10,18 @@ namespace epay3.Web.Api.Tests
     public class IvrSessionsFixture
     {
         private IvrSessionsApi _ivrSessionsApi;
+        private ITestData _testData;
 
         [TestInitialize]
         public void Initialize()
         {
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
 
-            _ivrSessionsApi = new IvrSessionsApi(TestApiSettings.Uri);
+            _testData = new TestData.Processor12();
 
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.Key + ":" + TestApiSettings.Secret);
+            _ivrSessionsApi = new IvrSessionsApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
 
             _ivrSessionsApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
         }
@@ -61,7 +60,7 @@ namespace epay3.Web.Api.Tests
                 Expiration = 10
             };
 
-            bool success = _ivrSessionsApi.IvrSessionsPost(postTokenPageSessionRequestModel, TestApiSettings.ImpersonationAccountKey);
+            bool success = _ivrSessionsApi.IvrSessionsPost(postTokenPageSessionRequestModel, _testData.ImpersonationAccountKey);
 
             // Should post successfully.
             Assert.IsTrue(success);

--- a/epay3.Web.Api.Tests/Processor12/TransactionsFixture.cs
+++ b/epay3.Web.Api.Tests/Processor12/TransactionsFixture.cs
@@ -1,0 +1,85 @@
+﻿using epay3.Web.Api.Sdk.Api;
+using epay3.Web.Api.Sdk.Model;
+using epay3.Web.Api.Tests.TestData;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace epay3.Web.Api.Tests.Processor12
+{
+    [TestClass]
+    public class When_Posting_A_Transaction
+    {
+        private TokensApi _tokensApi;
+        private TransactionsApi _transactionsApi;
+        private ITestData _testData;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
+            _testData = new TestData.Processor12();
+
+            _transactionsApi = new TransactionsApi(_testData.Uri);
+            _tokensApi = new TokensApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
+
+            _tokensApi.Configuration.AddDefaultHeader("Authorization", "Basic " + Convert.ToBase64String(plainTextBytes));
+            _transactionsApi.Configuration.AddDefaultHeader("Authorization", "Basic " + Convert.ToBase64String(plainTextBytes));
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Process_And_Void_Credit_Card()
+        {
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                CreditCardInformation = _testData.Amex,
+                AttributeValues = new System.Collections.Generic.Dictionary<string, string> { { "phoneNumber", "512-234-1233" }, { "agentCode", "213498" } },
+                Comments = "Sample comments",
+                PayerFee = amount * .10
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+
+            // Should successfully void a transaction.
+            Assert.AreEqual(ReversalResponseCode.Success, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }).ReversalResponseCode);
+
+            var getTransactionResponseModel = _transactionsApi.TransactionsGet(response.Id.Value);
+
+            Assert.IsNotNull(getTransactionResponseModel);
+            Assert.AreEqual("512-234-1233", getTransactionResponseModel.AttributeValues.Single(x => x.ParameterName == "phoneNumber").Value);
+            Assert.IsNotNull(getTransactionResponseModel.Events.SingleOrDefault(x => x.EventType == EventType.Sale));
+            Assert.IsNotNull(getTransactionResponseModel.Events.SingleOrDefault(x => x.EventType == EventType.Void));
+
+            // Should not be able to void the transaction more than once.
+            Assert.AreEqual(ReversalResponseCode.PreviouslyVoided, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }).ReversalResponseCode);
+        }
+
+        [TestMethod]
+        public void Should_Fail_With_Invalid_Authorization_Id()
+        {
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                AuthorizationId = "INVALID_ID"
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            Assert.AreEqual(PaymentResponseCode.InvalidAuthorization, response.PaymentResponseCode);
+        }
+    }
+}

--- a/epay3.Web.Api.Tests/Processor12/TransactionsFixture.cs
+++ b/epay3.Web.Api.Tests/Processor12/TransactionsFixture.cs
@@ -34,7 +34,8 @@ namespace epay3.Web.Api.Tests.Processor12
         [TestMethod]
         public void Should_Successfully_Process_And_Void_Credit_Card()
         {
-            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            // processor requires an amount 'around $35'
+            var amount = 34 + Math.Round(new Random().NextDouble() * 10, 2);
             var postTransactionRequestModel = new PostTransactionRequestModel
             {
                 Payer = "John Smith",

--- a/epay3.Web.Api.Tests/Processor13/TransactionsFixture.cs
+++ b/epay3.Web.Api.Tests/Processor13/TransactionsFixture.cs
@@ -1,0 +1,264 @@
+﻿using epay3.Web.Api.Sdk.Api;
+using epay3.Web.Api.Sdk.Model;
+using epay3.Web.Api.Tests.TestData;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace epay3.Web.Api.Tests.Processor13
+{
+    // TODO: 20220302 RHH - Remove this [Ignore] once Processor 13 is live on the sandbox & account #334 is properly configured
+    [Ignore]
+    [TestClass]
+    public class When_Posting_A_Transaction
+    {
+        private TokensApi _tokensApi;
+        private TransactionsApi _transactionsApi;
+        private ITestData _testData;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
+            _testData = new TestData.Processor13();
+
+            _transactionsApi = new TransactionsApi(_testData.Uri);
+            _tokensApi = new TokensApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
+
+            _tokensApi.Configuration.AddDefaultHeader("Authorization", "Basic " + Convert.ToBase64String(plainTextBytes));
+            _transactionsApi.Configuration.AddDefaultHeader("Authorization", "Basic " + Convert.ToBase64String(plainTextBytes));
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Process_And_Void_Credit_Card()
+        {
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                CreditCardInformation = _testData.Mastercard,
+                AttributeValues = new System.Collections.Generic.Dictionary<string, string> { { "phoneNumber", "512-234-1233" }, { "agentCode", "213498" } },
+                Comments = "Sample comments",
+                PayerFee = amount * .10
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+
+            // Should successfully void a transaction.
+            Assert.AreEqual(ReversalResponseCode.Success, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }).ReversalResponseCode);
+
+            var getTransactionResponseModel = _transactionsApi.TransactionsGet(response.Id.Value);
+
+            Assert.IsNotNull(getTransactionResponseModel);
+            Assert.AreEqual("512-234-1233", getTransactionResponseModel.AttributeValues.Single(x => x.ParameterName == "phoneNumber").Value);
+            Assert.IsNotNull(getTransactionResponseModel.Events.SingleOrDefault(x => x.EventType == EventType.Sale));
+            Assert.IsNotNull(getTransactionResponseModel.Events.SingleOrDefault(x => x.EventType == EventType.Void));
+
+            // Should not be able to void the transaction more than once.
+            Assert.AreEqual(ReversalResponseCode.PreviouslyVoided, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }).ReversalResponseCode);
+        }
+
+        [TestMethod]
+        public void Should_Honor_Impersonation_For_Transactions()
+        {
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                BankAccountInformation = _testData.Ach2,
+                Comments = "Sample comments",
+                InitiatingPartyFee = amount * .20
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, _testData.ImpersonationAccountKey);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+            Assert.AreEqual(PaymentResponseCode.Success, response.PaymentResponseCode);
+
+            // Should get the transaction even when impersonation is off.
+            Assert.IsNotNull(_transactionsApi.TransactionsGet(response.Id, null));
+            // Should get the transaction when impersonation is on.
+            Assert.IsNotNull(_transactionsApi.TransactionsGet(response.Id, _testData.ImpersonationAccountKey));
+
+            // Should not be able to void with the impersonation key.
+            Assert.AreNotEqual(ReversalResponseCode.Success, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }, null));
+
+            // Should be able to void with the impersonation key.
+            Assert.AreEqual(ReversalResponseCode.Success, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }, _testData.ImpersonationAccountKey).ReversalResponseCode);
+        }
+
+        /// <summary>
+        /// This is just an example showing how to refund a transaction. Refunds are not allowed until
+        /// the transaction is settled and batched.
+        /// </summary>
+        [TestMethod]
+        [Ignore]
+        public void Should_Successfully_Issue_Full_Refund()
+        {
+            var amount = new Random().Next(10, 1000);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                BankAccountInformation = _testData.Ach2,
+                Comments = "Sample comments"
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+
+            var refundResponse = _transactionsApi.TransactionsRefund(response.Id.Value, new PostRefundTransactionRequestModel { SendReceipt = false });
+            var refundTransaction = _transactionsApi.TransactionsGet(refundResponse.Id);
+
+            Assert.IsNotNull(refundTransaction);
+            Assert.AreEqual(refundTransaction.Amount * -1, postTransactionRequestModel.Amount + 3);
+        }
+
+        /// <summary>
+        /// This is just an example showing how to refund a transaction. Refunds are not allowed until
+        /// the transaction is settled and batched.
+        /// </summary>
+        [TestMethod]
+        [Ignore]
+        public void Should_Successfully_Issue_Partial_Refunds()
+        {
+            var amount = new Random().Next(100, 1000);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                BankAccountInformation = _testData.Ach2,
+                Comments = "Sample comments"
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+
+            var refundResponse = _transactionsApi.TransactionsRefund(response.Id.Value, new PostRefundTransactionRequestModel { SendReceipt = false, Amount = 5 });
+            var refundTransaction = _transactionsApi.TransactionsGet(refundResponse.Id);
+
+            Assert.IsNotNull(refundTransaction);
+            Assert.AreEqual(refundTransaction.Amount * -1, 5);
+
+            refundResponse = _transactionsApi.TransactionsRefund(response.Id.Value, new PostRefundTransactionRequestModel { SendReceipt = false, Amount = 6 });
+            refundTransaction = _transactionsApi.TransactionsGet(refundResponse.Id);
+
+            Assert.IsNotNull(refundTransaction);
+            Assert.AreEqual(refundTransaction.Amount * -1, 6);
+
+            refundResponse = _transactionsApi.TransactionsRefund(response.Id.Value, new PostRefundTransactionRequestModel { SendReceipt = false, Amount = postTransactionRequestModel.Amount });
+
+            Assert.AreEqual(ReversalResponseCode.GenericDecline, refundResponse.ReversalResponseCode);
+            Assert.IsNull(refundResponse.Id);
+        }
+
+        [TestMethod]
+        public void Should_Fail_With_Invalid_Authorization_Id()
+        {
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                AuthorizationId = "INVALID_ID"
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            Assert.AreEqual(PaymentResponseCode.InvalidAuthorization, response.PaymentResponseCode);
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Use_Authorization_Id()
+        {
+            var postTokenRequestModel = new PostTokenRequestModel
+            {
+                Payer = "John Doe",
+                EmailAddress = "jdoe@example.com",
+                CreditCardInformation = _testData.Mastercard
+            };
+
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel);
+
+            var authorizationId = _transactionsApi.TransactionsAuthorize(new PostAuthorizeTransactionRequestModel
+            {
+                Amount = amount,
+                TokenId = tokenId
+            });
+
+            Assert.IsNotNull(authorizationId);
+
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                AuthorizationId = authorizationId
+            };
+
+            var transactionResponse = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            Assert.AreEqual(PaymentResponseCode.Success, transactionResponse.PaymentResponseCode);
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Use_Authorization_Id_With_Impersonation()
+        {
+            var postTokenRequestModel = new PostTokenRequestModel
+            {
+                Payer = "John Doe",
+                EmailAddress = "jdoe@example.com",
+                CreditCardInformation = _testData.Mastercard
+            };
+
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel, _testData.ImpersonationAccountKey);
+
+            var authorizationId = _transactionsApi.TransactionsAuthorize(new PostAuthorizeTransactionRequestModel
+            {
+                Amount = amount,
+                TokenId = tokenId
+            }, _testData.ImpersonationAccountKey);
+
+            Assert.IsNotNull(authorizationId, _testData.ImpersonationAccountKey);
+
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                AuthorizationId = authorizationId
+            };
+
+            // This attempt should fail without the same impersonation key.
+            var transactionResponse = _transactionsApi.TransactionsPost(postTransactionRequestModel);
+
+            Assert.AreEqual(PaymentResponseCode.InvalidAuthorization, transactionResponse.PaymentResponseCode);
+
+            // This attempt should succeed with the the correct impersonation key.
+            transactionResponse = _transactionsApi.TransactionsPost(postTransactionRequestModel, _testData.ImpersonationAccountKey);
+
+            Assert.AreEqual(PaymentResponseCode.Success, transactionResponse.PaymentResponseCode);
+        }
+    }
+}

--- a/epay3.Web.Api.Tests/Processor7/TransactionsFixture.cs
+++ b/epay3.Web.Api.Tests/Processor7/TransactionsFixture.cs
@@ -1,0 +1,333 @@
+﻿using epay3.Web.Api.Sdk.Api;
+using epay3.Web.Api.Sdk.Client;
+using epay3.Web.Api.Sdk.Model;
+using epay3.Web.Api.Tests.TestData;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace epay3.Web.Api.Tests.Processor7
+{
+    [TestClass]
+    public class When_Posting_A_Transaction
+    {
+        private TokensApi _tokensApi;
+        private TransactionsApi _transactionsApi;
+        private ITestData _testData;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
+            _testData = new TestData.Processor7();
+
+            _transactionsApi = new TransactionsApi(_testData.Uri);
+            _tokensApi = new TokensApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
+
+            _tokensApi.Configuration.AddDefaultHeader("Authorization", "Basic " + Convert.ToBase64String(plainTextBytes));
+            _transactionsApi.Configuration.AddDefaultHeader("Authorization", "Basic " + Convert.ToBase64String(plainTextBytes));
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Process_And_Void_Credit_Card()
+        {
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                CreditCardInformation = _testData.Mastercard,
+                AttributeValues = new System.Collections.Generic.Dictionary<string, string> { { "phoneNumber", "512-234-1233" }, { "agentCode", "213498" } },
+                Comments = "Sample comments",
+                PayerFee = amount * .10
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+
+            // Should successfully void a transaction.
+            Assert.AreEqual(ReversalResponseCode.Success, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }).ReversalResponseCode);
+
+            var getTransactionResponseModel = _transactionsApi.TransactionsGet(response.Id.Value);
+
+            Assert.IsNotNull(getTransactionResponseModel);
+            Assert.AreEqual("512-234-1233", getTransactionResponseModel.AttributeValues.Single(x => x.ParameterName == "phoneNumber").Value);
+            Assert.IsNotNull(getTransactionResponseModel.Events.SingleOrDefault(x => x.EventType == EventType.Sale));
+            Assert.IsNotNull(getTransactionResponseModel.Events.SingleOrDefault(x => x.EventType == EventType.Void));
+
+            // Should not be able to void the transaction more than once.
+            Assert.AreEqual(ReversalResponseCode.PreviouslyVoided, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }).ReversalResponseCode);
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Process_And_Void_Ach()
+        {
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = Math.Round(new Random().NextDouble() * 100, 2),
+                BankAccountInformation = _testData.Ach2,
+                AttributeValues = new System.Collections.Generic.Dictionary<string, string> { { "phoneNumber", "512-234-1233" }, { "agentCode", "213498" } },
+                Comments = "Sample comments"
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+
+            // Should successfully void a transaction.
+            Assert.AreEqual(ReversalResponseCode.Success, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }).ReversalResponseCode);
+
+            var getTransactionResponseModel = _transactionsApi.TransactionsGet(response.Id.Value);
+
+            Assert.IsNotNull(getTransactionResponseModel);
+            Assert.AreEqual("512-234-1233", getTransactionResponseModel.AttributeValues.Single(x => x.ParameterName == "phoneNumber").Value);
+            Assert.IsNotNull(getTransactionResponseModel.Events.SingleOrDefault(x => x.EventType == EventType.Sale));
+            Assert.IsNotNull(getTransactionResponseModel.Events.SingleOrDefault(x => x.EventType == EventType.Void));
+
+            // Should not be able to void the transaction more than once.
+            Assert.AreEqual(ReversalResponseCode.PreviouslyVoided, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }).ReversalResponseCode);
+        }
+
+        [TestMethod]
+        public void Should_Honor_Impersonation_For_Transactions()
+        {
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                BankAccountInformation = _testData.Ach2,
+                Comments = "Sample comments",
+                InitiatingPartyFee = amount * .20
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, _testData.ImpersonationAccountKey);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+            Assert.AreEqual(PaymentResponseCode.Success, response.PaymentResponseCode);
+
+            // Should get the transaction even when impersonation is off.
+            Assert.IsNotNull(_transactionsApi.TransactionsGet(response.Id, null));
+            // Should get the transaction when impersonation is on.
+            Assert.IsNotNull(_transactionsApi.TransactionsGet(response.Id, _testData.ImpersonationAccountKey));
+
+            // Should not be able to void with the impersonation key.
+            Assert.AreNotEqual(ReversalResponseCode.Success, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }, null));
+
+            // Should be able to void with the impersonation key.
+            Assert.AreEqual(ReversalResponseCode.Success, _transactionsApi.TransactionsVoid(response.Id.Value, new PostVoidTransactionRequestModel { SendReceipt = false }, _testData.ImpersonationAccountKey).ReversalResponseCode);
+        }
+
+        /// <summary>
+        /// This is just an example showing how to refund a transaction. Refunds are not allowed until
+        /// the transaction is settled and batched.
+        /// </summary>
+        [TestMethod]
+        [Ignore]
+        public void Should_Successfully_Issue_Full_Refund()
+        {
+            var amount = new Random().Next(10, 1000);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                BankAccountInformation = _testData.Ach2,
+                Comments = "Sample comments"
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+
+            var refundResponse = _transactionsApi.TransactionsRefund(response.Id.Value, new PostRefundTransactionRequestModel { SendReceipt = false });
+            var refundTransaction = _transactionsApi.TransactionsGet(refundResponse.Id);
+
+            Assert.IsNotNull(refundTransaction);
+            Assert.AreEqual(refundTransaction.Amount * -1, postTransactionRequestModel.Amount + 3);
+        }
+
+        /// <summary>
+        /// This is just an example showing how to refund a transaction. Refunds are not allowed until
+        /// the transaction is settled and batched.
+        /// </summary>
+        [TestMethod]
+        [Ignore]
+        public void Should_Successfully_Issue_Partial_Refunds()
+        {
+            var amount = new Random().Next(100, 1000);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                BankAccountInformation = _testData.Ach2,
+                Comments = "Sample comments"
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel);
+
+            // Should return a valid Id.
+            Assert.IsTrue(response.Id > 0);
+
+            var refundResponse = _transactionsApi.TransactionsRefund(response.Id.Value, new PostRefundTransactionRequestModel { SendReceipt = false, Amount = 5 });
+            var refundTransaction = _transactionsApi.TransactionsGet(refundResponse.Id);
+
+            Assert.IsNotNull(refundTransaction);
+            Assert.AreEqual(refundTransaction.Amount * -1, 5);
+
+            refundResponse = _transactionsApi.TransactionsRefund(response.Id.Value, new PostRefundTransactionRequestModel { SendReceipt = false, Amount = 6 });
+            refundTransaction = _transactionsApi.TransactionsGet(refundResponse.Id);
+
+            Assert.IsNotNull(refundTransaction);
+            Assert.AreEqual(refundTransaction.Amount * -1, 6);
+
+            refundResponse = _transactionsApi.TransactionsRefund(response.Id.Value, new PostRefundTransactionRequestModel { SendReceipt = false, Amount = postTransactionRequestModel.Amount });
+
+            Assert.AreEqual(ReversalResponseCode.GenericDecline, refundResponse.ReversalResponseCode);
+            Assert.IsNull(refundResponse.Id);
+        }
+
+        [TestMethod]
+        public void Should_Fail_With_Invalid_Authorization_Id()
+        {
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                AuthorizationId = "INVALID_ID"
+            };
+
+            var response = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            Assert.AreEqual(PaymentResponseCode.InvalidAuthorization, response.PaymentResponseCode);
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Use_Authorization_Id()
+        {
+            var postTokenRequestModel = new PostTokenRequestModel
+            {
+                Payer = "John Doe",
+                EmailAddress = "jdoe@example.com",
+                CreditCardInformation = _testData.Mastercard
+            };
+
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel);
+
+            var authorizationId = _transactionsApi.TransactionsAuthorize(new PostAuthorizeTransactionRequestModel
+            {
+                Amount = amount,
+                TokenId = tokenId
+            });
+
+            Assert.IsNotNull(authorizationId);
+
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                AuthorizationId = authorizationId
+            };
+
+            var transactionResponse = _transactionsApi.TransactionsPost(postTransactionRequestModel, null);
+
+            Assert.AreEqual(PaymentResponseCode.Success, transactionResponse.PaymentResponseCode);
+        }
+
+        [TestMethod]
+        public void Should_Not_Successfully_Authorization_With_Ach_Token()
+        {
+            var postTokenRequestModel = new PostTokenRequestModel
+            {
+                Payer = "John Doe",
+                EmailAddress = "jdoe@example.com",
+                BankAccountInformation = new BankAccountInformationModel
+                {
+                    AccountHolder = "John Doe",
+                    AccountNumber = "1234567890",
+                    RoutingNumber = "111000025",
+                    AccountType = AccountType.Corporatesavings
+                }
+            };
+
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel);
+
+            try
+            {
+                var authorizationId = _transactionsApi.TransactionsAuthorize(new PostAuthorizeTransactionRequestModel
+                {
+                    Amount = amount,
+                    TokenId = tokenId
+                });
+
+                Assert.Fail();
+            }
+            catch (ApiException)
+            {
+            }
+            catch
+            {
+                Assert.Fail();
+            }
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Use_Authorization_Id_With_Impersonation()
+        {
+            var postTokenRequestModel = new PostTokenRequestModel
+            {
+                Payer = "John Doe",
+                EmailAddress = "jdoe@example.com",
+                CreditCardInformation = _testData.Mastercard
+            };
+
+            var amount = Math.Round(new Random().NextDouble() * 100, 2);
+            var tokenId = _tokensApi.TokensPost(postTokenRequestModel, _testData.ImpersonationAccountKey);
+
+            var authorizationId = _transactionsApi.TransactionsAuthorize(new PostAuthorizeTransactionRequestModel
+            {
+                Amount = amount,
+                TokenId = tokenId
+            }, _testData.ImpersonationAccountKey);
+
+            Assert.IsNotNull(authorizationId, _testData.ImpersonationAccountKey);
+
+            var postTransactionRequestModel = new PostTransactionRequestModel
+            {
+                Payer = "John Smith",
+                EmailAddress = "jsmith@example.com",
+                Amount = amount,
+                AuthorizationId = authorizationId
+            };
+
+            // This attempt should fail without the same impersonation key.
+            var transactionResponse = _transactionsApi.TransactionsPost(postTransactionRequestModel);
+
+            Assert.AreEqual(PaymentResponseCode.InvalidAuthorization, transactionResponse.PaymentResponseCode);
+
+            // This attempt should succeed with the the correct impersonation key.
+            transactionResponse = _transactionsApi.TransactionsPost(postTransactionRequestModel, _testData.ImpersonationAccountKey);
+
+            Assert.AreEqual(PaymentResponseCode.Success, transactionResponse.PaymentResponseCode);
+        }
+    }
+}

--- a/epay3.Web.Api.Tests/TestData/IAccountConfig.cs
+++ b/epay3.Web.Api.Tests/TestData/IAccountConfig.cs
@@ -1,0 +1,15 @@
+﻿namespace epay3.Web.Api.Tests.TestData
+{
+    public interface IAccountConfig
+    {
+        string Uri { get; }
+        string Key { get; }
+        string Secret { get; }
+        string PublicKey { get; }
+        long ImpersonationOnlyBatchId { get; }
+        string ImpersonationAccountKey { get; }
+        string InvoiceKey { get; }
+        string InvoiceSecret { get; }
+        string InvoicesImpersonationAccountKey { get; }
+    }
+}

--- a/epay3.Web.Api.Tests/TestData/IProcessorTestData.cs
+++ b/epay3.Web.Api.Tests/TestData/IProcessorTestData.cs
@@ -1,0 +1,13 @@
+﻿using epay3.Web.Api.Sdk.Model;
+
+namespace epay3.Web.Api.Tests.TestData
+{
+    public interface IProcessorTestData
+    {
+        BankAccountInformationModel Ach1 { get; }
+        BankAccountInformationModel Ach2 { get; }
+        CreditCardInformationModel Amex { get; }
+        CreditCardInformationModel Mastercard { get; }
+        CreditCardInformationModel Visa { get; }
+    }
+}

--- a/epay3.Web.Api.Tests/TestData/ITestData.cs
+++ b/epay3.Web.Api.Tests/TestData/ITestData.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace epay3.Web.Api.Tests.TestData
+{
+    interface ITestData : IProcessorTestData, IAccountConfig
+    {
+    }
+}

--- a/epay3.Web.Api.Tests/TestData/Processor12.cs
+++ b/epay3.Web.Api.Tests/TestData/Processor12.cs
@@ -21,10 +21,10 @@ namespace epay3.Web.Api.Tests.TestData
         public CreditCardInformationModel Amex => new CreditCardInformationModel()
         {
             AccountHolder = "John Doe",
-            CardNumber = "373953192351004",
+            CardNumber = "341111599241000",
             Month = 12,
-            Year = 2023,
-            Cvc = "991",
+            Year = DateTime.Now.Year + 1,
+            Cvc = "9395",
             PostalCode = "54321"
         };
 

--- a/epay3.Web.Api.Tests/TestData/Processor12.cs
+++ b/epay3.Web.Api.Tests/TestData/Processor12.cs
@@ -1,0 +1,35 @@
+﻿using epay3.Web.Api.Sdk.Model;
+using System;
+
+namespace epay3.Web.Api.Tests.TestData
+{
+    /// <summary>
+    /// Uses keys for Account #333 in the sandbox. Can only process AMEX credit cards.
+    /// </summary>
+    public class Processor12 : TestApiSettings, ITestData
+    {
+        public override string Key => System.Configuration.ConfigurationManager.AppSettings["ApiKey_Processor12"];
+
+        public override string Secret => System.Configuration.ConfigurationManager.AppSettings["ApiSecret_Processor12"];
+
+        public override string PublicKey => System.Configuration.ConfigurationManager.AppSettings["ApiPublicKey_Processor12"];
+
+        public BankAccountInformationModel Ach1 => throw new NotImplementedException();
+
+        public BankAccountInformationModel Ach2 => throw new NotImplementedException();
+
+        public CreditCardInformationModel Amex => new CreditCardInformationModel()
+        {
+            AccountHolder = "John Doe",
+            CardNumber = "373953192351004",
+            Month = 12,
+            Year = 2023,
+            Cvc = "991",
+            PostalCode = "54321"
+        };
+
+        public CreditCardInformationModel Mastercard => throw new NotImplementedException();
+
+        public CreditCardInformationModel Visa => throw new NotImplementedException();
+    }
+}

--- a/epay3.Web.Api.Tests/TestData/Processor13.cs
+++ b/epay3.Web.Api.Tests/TestData/Processor13.cs
@@ -1,0 +1,51 @@
+﻿using epay3.Web.Api.Sdk.Model;
+using System;
+
+namespace epay3.Web.Api.Tests.TestData
+{
+    /// <summary>
+    /// Uses keys for Account #334 in the sandbox. Can only process credit cards.
+    /// </summary>
+    public class Processor13 : TestApiSettings, ITestData
+    {
+        public override string Key => System.Configuration.ConfigurationManager.AppSettings["ApiKey_Processor13"];
+
+        public override string Secret => System.Configuration.ConfigurationManager.AppSettings["ApiSecret_Processor13"];
+
+        public override string PublicKey => System.Configuration.ConfigurationManager.AppSettings["ApiPublicKey_Processor13"];
+
+        public BankAccountInformationModel Ach1 => throw new NotImplementedException();
+
+        public BankAccountInformationModel Ach2 => throw new NotImplementedException();
+
+        public CreditCardInformationModel Amex => new CreditCardInformationModel()
+        {
+            AccountHolder = "John Doe",
+            CardNumber = "370000000000002",
+            Month = 3,
+            Year = 2030,
+            Cvc = "7373",
+            PostalCode = "54321"
+        };
+
+        public CreditCardInformationModel Mastercard => new CreditCardInformationModel()
+        {
+            AccountHolder = "John Doe",
+            CardNumber = "5555341244441115",
+            Month = 3,
+            Year = 2030,
+            Cvc = "737",
+            PostalCode = "54321"
+        };
+
+        public CreditCardInformationModel Visa => new CreditCardInformationModel
+        {
+            AccountHolder = "John Doe",
+            CardNumber = "4111111145551142",
+            Cvc = "737",
+            Month = 3,
+            Year = 2030,
+            PostalCode = "54321"
+        };
+    }
+}

--- a/epay3.Web.Api.Tests/TestData/Processor7.cs
+++ b/epay3.Web.Api.Tests/TestData/Processor7.cs
@@ -1,0 +1,61 @@
+﻿using epay3.Web.Api.Sdk.Model;
+using System;
+
+namespace epay3.Web.Api.Tests.TestData
+{
+    /// <summary>
+    /// Uses keys for Account #11 in the sandbox. Can process both credit cards and ACH transactions.
+    /// </summary>
+    public class Processor7 : TestApiSettings, ITestData
+    {
+        public  BankAccountInformationModel Ach1 => new BankAccountInformationModel
+        {
+            FirstName = "John",
+            LastName = "Smith",
+            RoutingNumber = "111000025",
+            AccountNumber = "1234567890",
+            AccountHolder = "ACME Corp",
+            AccountType = AccountType.Corporatechecking
+        };
+
+        public  BankAccountInformationModel Ach2 => new BankAccountInformationModel
+        {
+            AccountHolder = "John Smith",
+            FirstName = "John",
+            LastName = "Smith",
+            AccountNumber = "5454545454545454",
+            RoutingNumber = "111000025",
+            AccountType = AccountType.Personalsavings
+        };
+
+        public  CreditCardInformationModel Amex => new CreditCardInformationModel()
+        {
+            AccountHolder = "John Doe",
+            CardNumber = "371449635398431",
+            Cvc = "3714",
+            Month = 12,
+            Year = DateTime.Now.Year + 1,
+            PostalCode = "54321"
+        };
+
+        public  CreditCardInformationModel Mastercard => new CreditCardInformationModel
+        {
+            AccountHolder = "John Doe",
+            CardNumber = "5454545454545454",
+            Cvc = "999",
+            Month = 12,
+            Year = DateTime.Now.Year + 1,
+            PostalCode = "54321"
+        };
+
+        public  CreditCardInformationModel Visa => new CreditCardInformationModel
+        {
+            AccountHolder = "John Doe",
+            CardNumber = "4457119922390123",
+            Cvc = "123",
+            Month = 12,
+            Year = DateTime.Now.Year + 1,
+            PostalCode = "54321"
+        };
+    }
+}

--- a/epay3.Web.Api.Tests/TestData/TestApiSettings.cs
+++ b/epay3.Web.Api.Tests/TestData/TestApiSettings.cs
@@ -1,0 +1,73 @@
+﻿using epay3.Web.Api.Tests.TestData;
+
+namespace epay3.Web.Api.Tests
+{
+    public class TestApiSettings : IAccountConfig
+    {
+        public string Uri
+        {
+            get
+            {
+                return System.Configuration.ConfigurationManager.AppSettings["ApiUri"];
+            }
+        }
+
+        public virtual string Key
+        {
+            get
+            {
+                return System.Configuration.ConfigurationManager.AppSettings["ApiKey"];
+            }
+        }
+
+        public virtual string Secret
+        {
+            get
+            {
+                return System.Configuration.ConfigurationManager.AppSettings["ApiSecret"];
+            }
+        }
+
+        public virtual string PublicKey
+        {
+            get
+            {
+                return System.Configuration.ConfigurationManager.AppSettings["ApiPublicKey"];
+            }
+        }
+
+        public string InvoiceKey
+        {
+            get
+            {
+                return System.Configuration.ConfigurationManager.AppSettings["InvoiceApiKey"];
+            }
+        }
+
+        public string InvoiceSecret
+        {
+            get
+            {
+                return System.Configuration.ConfigurationManager.AppSettings["InvoiceApiSecret"];
+            }
+        }
+
+        public string ImpersonationAccountKey
+        {
+            get
+            {
+                return System.Configuration.ConfigurationManager.AppSettings["ImpersonationAccountKey"];
+            }
+        }
+
+        public string InvoicesImpersonationAccountKey
+        {
+            get
+            {
+                return System.Configuration.ConfigurationManager.AppSettings["InvoicesImpersonationAccountKey"];
+            }
+        }
+
+        public long ImpersonationOnlyBatchId => long.Parse(System.Configuration.ConfigurationManager.AppSettings["ImpersonationOnlyBatchId"]);
+    }
+}

--- a/epay3.Web.Api.Tests/TokenPageSessionsFixture.cs
+++ b/epay3.Web.Api.Tests/TokenPageSessionsFixture.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using epay3.Web.Api.Sdk.Api;
+﻿using epay3.Web.Api.Sdk.Api;
 using epay3.Web.Api.Sdk.Model;
-using epay3.Web.Api.Sdk.Client;
+using epay3.Web.Api.Tests.TestData;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net;
-using System.Linq;
 
 namespace epay3.Web.Api.Tests
 {
@@ -11,15 +10,18 @@ namespace epay3.Web.Api.Tests
     public class TokenPageSessionsFixture
     {
         private TokenPageSessionsApi _tokenPageSessionsApi;
+        private ITestData _testData;
 
         [TestInitialize]
         public void Initialize()
         {
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
 
-            _tokenPageSessionsApi = new TokenPageSessionsApi(TestApiSettings.Uri);
+            _testData = new TestData.Processor7();
 
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.Key + ":" + TestApiSettings.Secret);
+            _tokenPageSessionsApi = new TokenPageSessionsApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
 
             _tokenPageSessionsApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
         }
@@ -57,7 +59,7 @@ namespace epay3.Web.Api.Tests
                 SuccessUrl = "https://www.example.com"
             };
 
-            var id = _tokenPageSessionsApi.TokenPageSessionsPost(postTokenPageSessionRequestModel, TestApiSettings.ImpersonationAccountKey);
+            var id = _tokenPageSessionsApi.TokenPageSessionsPost(postTokenPageSessionRequestModel, _testData.ImpersonationAccountKey);
 
             // Should return a valid Id.
             Assert.IsNotNull(id);

--- a/epay3.Web.Api.Tests/TransactionFeesFixture.cs
+++ b/epay3.Web.Api.Tests/TransactionFeesFixture.cs
@@ -1,5 +1,6 @@
 ﻿using epay3.Web.Api.Sdk.Api;
 using epay3.Web.Api.Sdk.Model;
+using epay3.Web.Api.Tests.TestData;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Net;
@@ -11,16 +12,19 @@ namespace epay3.Web.Api.Tests
     {
         private TransactionFeesApi _transactionFeesApi;
         private TokensApi _tokensApi;
+        private ITestData _testData;
 
         [TestInitialize]
         public void Initialize()
         {
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
 
-            _transactionFeesApi = new TransactionFeesApi(TestApiSettings.Uri);
-            _tokensApi = new TokensApi(TestApiSettings.Uri);
+            _testData = new TestData.Processor7();
 
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(TestApiSettings.Key + ":" + TestApiSettings.Secret);
+            _transactionFeesApi = new TransactionFeesApi(_testData.Uri);
+            _tokensApi = new TokensApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
 
             _transactionFeesApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
             _tokensApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
@@ -39,7 +43,7 @@ namespace epay3.Web.Api.Tests
         [TestMethod]
         public void ShouldReturnValuesWithImpersonationKey()
         {
-            var response = _transactionFeesApi.TransactionFeesGet(5.3m, null, TestApiSettings.ImpersonationAccountKey);
+            var response = _transactionFeesApi.TransactionFeesGet(5.3m, null, _testData.ImpersonationAccountKey);
 
             Assert.IsInstanceOfType(response, typeof(GetTransactionFeesResponseModel));
             Assert.IsNotNull(response.AchPayerFee);

--- a/epay3.Web.Api.Tests/TransactionSearchFixture.cs
+++ b/epay3.Web.Api.Tests/TransactionSearchFixture.cs
@@ -1,0 +1,64 @@
+﻿using epay3.Web.Api.Sdk.Api;
+using epay3.Web.Api.Sdk.Model;
+using epay3.Web.Api.Tests.TestData;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace epay3.Web.Api.Tests
+{
+    [TestClass]
+    public class When_Searching_Transactions
+    {
+        private TransactionsApi _transactionsApi;
+        private BatchesApi _batchesApi;
+        private ITestData _testData;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
+            _testData = new TestData.Processor7();
+
+            _transactionsApi = new TransactionsApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
+
+            _transactionsApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Find_Transactions()
+        {
+            // Search results can be iterated through, with each returned transaction coming back in the form of a GetTransactionResponseModel.
+            var searchResults = _transactionsApi.TransactionsSearch(beginDate: DateTime.Parse("1/1/2020"), endDate: DateTime.UtcNow,
+                transactionSearchTypeId: TransactionSearchType.Processed, minAmount: -200m, maxAmount: 1000m, pageSize: 5, page: 1, impersonationAccountKey: _testData.ImpersonationAccountKey);
+            Assert.IsNotNull(searchResults);
+
+            // Additionally, every parameter when searching for transactions is optional.
+            var searchAllResults = _transactionsApi.TransactionsSearch();
+            Assert.IsTrue(searchAllResults.TotalRecords > 0);
+            Assert.IsNotNull(searchAllResults);
+        }
+
+        [TestMethod]
+        public void Should_Successfully_Finds_Transactions_For_Batch()
+        {
+            _batchesApi = new BatchesApi(_testData.Uri);
+
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(_testData.Key + ":" + _testData.Secret);
+
+            _batchesApi.Configuration.AddDefaultHeader("Authorization", "Basic " + System.Convert.ToBase64String(plainTextBytes));
+
+            var batchSearchResults = _batchesApi.BatchesGet(1);
+
+            Assert.IsTrue(batchSearchResults.Batches.Any());
+
+            var transactionSearchResults = _transactionsApi.TransactionsSearch(DateTime.MinValue, null, null, null, null, batchSearchResults.Batches.First().Id, null, null, null);
+
+            Assert.IsTrue(transactionSearchResults.Transactions.Any());
+        }
+    }
+}

--- a/epay3.Web.Api.Tests/epay3.Web.Api.Tests.csproj
+++ b/epay3.Web.Api.Tests/epay3.Web.Api.Tests.csproj
@@ -47,6 +47,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VS.QualityTools.UnitTestFramework.15.0.27323.2\lib\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -60,26 +63,30 @@
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="AutoPayFixture.cs" />
     <Compile Include="BatchesFixture.cs" />
     <Compile Include="InvoicesFixture.cs" />
     <Compile Include="IvrSessionsFixture.cs" />
-    <Compile Include="TransactionFeesFixture.cs" />
-    <Compile Include="PublicKeyFixture.cs" />
-    <Compile Include="TestApiSettings.cs" />
-    <Compile Include="TokenPageSessionsFixture.cs" />
-    <Compile Include="PaymentPageSessionsFixture.cs" />
-    <Compile Include="TokensFixture.cs" />
     <Compile Include="PaymentSchedulesFixture.cs" />
-    <Compile Include="TransactionsFixture.cs" />
+    <Compile Include="Processor13\TransactionsFixture.cs" />
+    <Compile Include="Processor12\TransactionsFixture.cs" />
+    <Compile Include="Processor7\TransactionsFixture.cs" />
+    <Compile Include="PublicKeyFixture.cs" />
+    <Compile Include="TestData\IAccountConfig.cs" />
+    <Compile Include="TestData\IProcessorTestData.cs" />
+    <Compile Include="TestData\ITestData.cs" />
+    <Compile Include="TestData\Processor13.cs" />
+    <Compile Include="TestData\Processor12.cs" />
+    <Compile Include="TestData\Processor7.cs" />
+    <Compile Include="TokensFixture.cs" />
+    <Compile Include="TransactionFeesFixture.cs" />
+    <Compile Include="TestData\TestApiSettings.cs" />
+    <Compile Include="TokenPageSessionsFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="AutoPayFixture.cs" />
+    <Compile Include="TransactionSearchFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\epay3.Web.Api.Sdk\epay3.Web.Api.Sdk.csproj">

--- a/epay3.Web.Api.Tests/packages.config
+++ b/epay3.Web.Api.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
+  <package id="VS.QualityTools.UnitTestFramework" version="15.0.27323.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Enhanced test suite to allow multiple accounts & multiple processors
Refactored the existing account settings as Processor7.
Added Processor12 (AMEX) & Processor13 (Future Processor) configurations and tests.
Refactored the existing tests to work from processor-specific setttings instead of TestApiSettings.
Updated VS.QualityTools.UnitTestFramework as a Nuget package
Updated transaction search date to be programmatic for avoiding timeouts